### PR TITLE
Add a status attribute - #1

### DIFF
--- a/Guidelines/Documentation-Correspondance.xml
+++ b/Guidelines/Documentation-Correspondance.xml
@@ -310,8 +310,8 @@
                                             and on its pages. <egXML xmlns="http://www.tei-c.org/ns/Examples">
                                                 <additions>
                                                     <p>A stamp has been put on almost every page of the correspondence by the institution in charge of
-                                                        the collection. On the stamp is written: <stamp resp="#stamp">Archives de la Sarthe <lb/>Propriété
-                                                    publique</stamp></p></additions>
+                                                        the collection. On the stamp is written: <stamp resp="#stamp">Archives de la Sarthe
+                                                            <lb/>Propriété publique</stamp></p></additions>
                                             </egXML></p>
                                         <p>Any material accompanying the letter—for example an envelope, a picture, a drawing etc.—is described inside
                                                 <gi>physDesc</gi> using the <gi>accMat</gi> element. Envelopes are usually regarded as part of the
@@ -461,6 +461,17 @@
                                             letters before proceeding with the transcription; the text sounds familiar.</change>
                                     </revisionDesc>
                                 </egXML></p>
+                            <p>The <gi>revisionDesc</gi> will also be used, in our documents, to indicate the level of finalization of the
+                                transcription published on the platform of our project. We have three level of transcription : <list>
+                                    <item>raw transcription</item>
+                                    <item>annotation in progress</item>
+                                    <item>finalized document</item>
+                                </list> Those different steps will be indicated with an attribute <att>status</att> with a value for each of those
+                                steps : <list>
+                                    <item><val>proposed</val>: the document is simply transcribed</item>
+                                    <item><val>unfinished</val>: the transcription is done and the annotation are in progress</item>
+                                    <item><val>approved</val>: the document is fully finalized</item>
+                                </list></p>
                         </div>
                     </div>
                 </div>

--- a/Transcription/Lettre477_4février1919.xml
+++ b/Transcription/Lettre477_4février1919.xml
@@ -185,7 +185,8 @@
                 <language ident="fr"/>
             </langUsage>
         </profileDesc>
-        <revisionDesc>
+        <revisionDesc status="proposed">
+            <change when-iso="2020-04-23" who="#floriane.chiffoleau">Transcription completed</change>
             <change when-iso="2020-04-02" who="#floriane.chiffoleau">Modifications on the encoding</change>
             <change when-iso="2020-04-01" who="#floriane.chiffoleau">Modifications on the encoding</change>
             <change when-iso="2020-03-19" who="#floriane.chiffoleau">Creation of the encoding (Body)</change>
@@ -234,7 +235,9 @@
                         <add place="inline"> </add>
                     </subst>femmes, des enfants, dont ils devaient sauvegarder la<lb rend="after:&quot;"/> sécurité et le bien-être… »</p>
                 <p/>
-                <p rend="indent">[…]</p>
+                <p rend="indent">Mon cher Butler, c’est pour avoir essayé,<lb/> depuis vingt and et davantage, de rappeler les dirigeants<lb/> à leur
+                    devoir que j’ai été mis en suspicion et paralysé. Si<lb/> ces dirigeants ne changent pas et de corps et d’âme, les<lb/> mêmes
+                    négligences, les mêmes fautes, les mêmes catastrophes<lb/> sont à prévoir, sont certaines.</p>
                 <p rend="indent">Il fallait voir la figure maussade de nos<lb/> ministres et l’aspect rogue et revêche de M. Poincaré pen<lb
                         break="no"/>dant qu’ils écoutaient, dans l’hémicycle, cet appel à plus<lb/> de prévoyance pour l’avenir, à plus de foi dans la
                         <hi rend="underline">Société<lb/> des Nations</hi>, acclamée avec enthousiasme par la gauche,<lb/> mais du bout des lèvres et
@@ -260,12 +263,32 @@
                     n’est pas<lb rend="after:&quot;"/> l’homme à faire la paix ».</p>
                 <p rend="indent">Et alors ? Nous allons voir les Américains,<lb/> les Anglais, partir froissés par la maladresse de nos<lb/>
                     gouvernements d’avant-guerre et tous les autres humiliés par<lb/> une sécheresse orgueilleuse qui est à mille lieues des<lb/>
-                    traditions séculaires et des aspirations fraternelles de<lb/> la France. […] </p>
+                    traditions séculaires et des aspirations fraternelles de<lb/> la France.</p>
                 <pb n="4" facs="P1170357.JPG"/>
                 <note type="foliation" place="top">- 4 -</note>
-                <p rend="indent">[…] <pb n="5" facs="P1170358.JPG"/>
-                    <note type="foliation" place="top">- 5 -</note>
-                </p>
+                <p rend="indent">Que nous soyons impitoyables pour exiger des<lb/> Allemands qu’ils paient leur dette, soit; que nous fassions<lb/>
+                    juger les Gouvernants Allemands, non pas par nous-même,<lb/> certes, mais de telle sorte que leur culpabilité ne puisse<lb/> être
+                    niée par personne, même et surtout en Allemagne; que<lb/> nous conservions des gages sans faire de conquêtes; tout<lb/> cela se
+                    conçoit, cela est nécessaire, dans la mesure où<lb/> nous ne rendrons pourtant pas impossible la reprise d’une<lb/> vie normale
+                    aux Allemands. Mais efforçons-nous de conser<lb break="no"/>ver d’autant plus la confiance et l’amitié de tous nos<lb/> Alliés. Ne
+                    les traitons ni par la défiance, ni par l’in<lb break="no"/>gratitude, ni, par le mépris.</p>
+                <p rend="indent">Je vous écris cela, à titre personne<add place="inline" hand="#annotation">l</add>, sachant<lb/> bien que vous n’oubliez pas le souci que j’ai toujours pris<lb/>
+                    de ne rien publier mais qui puisse affaiblir mon Gouverne<lb break="no"/>ment, non seulement devant l’ennemi mais devant ses
+                    Alliés.</p>
+                <p rend="indent">Cependant je ne dois pas, je ne puis pas<lb/> toujours me taire. Je n’attaque pas Clemenceau. Vous<lb/> m’avez vu
+                    maintes fois reconnaître sa supériorité, comparée<lb/> à la médiocrité de tant d’autres. Je n’oublie pas qu’il<lb/> a été l’ami
+                    des petits peuples en bien des cas, l’ami des<lb/> Grecs, par exemple, envers et contre tous, et jusqu’à <pb n="5"
+                        facs="P1170358.JPG"/>
+                    <note type="foliation" place="top">- 5 -</note> L’injustice. Mais en ce moment ses boutades de polémiste<lb/> peuvent indisposer
+                    nos amis, jeter le trouble dans leurs<lb/> esprits, les détourner du but de conciliation et de sacri<lb break="no"/>fice qui doit
+                    être le leur et le nôtre. N’oublions pas que<lb/> les Gouvernements des grands Etats ne sont que trop enclins<lb/> à dominer ou à
+                    ignorer les petits. Cela est si vrai,- je<lb/> vous le dis pour rétablir l’équilibre,- que Lloyd George<lb/> et le Président
+                    Wilson, plus politique qu’on ne pense,<lb/> laissent volontiers Clemenceau assumer pour eux l’impopula<lb break="no"/>rité d’un
+                    impérialisme qui ne peut être, chez nous, que<lb/> d’apparence, tandis qu’il serait chez eux autrement profond.<lb/> Les deux
+                    orgueils, anglais et américain, sont, en fait,<lb/> beaucoup plus durs pour les petits Etats que l’intransigeance<lb/> verbale de
+                    Clemenceau. Il est plus éloigné d’eux, sur ce<lb/> point, que de Bourgeois. Et c’est pourquoi je voudrais le<lb/> voir, plus
+                    habile, rallier autour de la France tous les<lb/> peuples faibles dont la cause est par excellence, comme la<lb/> nôtre, celle du
+                    Droit. Ce serait le plus sûr moyen de nous<lb/> assurer et de conserver le respect des grands.</p>
                 <closer>
                     <signed rend="align(right)">Votre affectueusement dévoué</signed>
                     <address rend="align(left)">


### PR DESCRIPTION
In response to the issue #1 and following what have been done on the [WeGa documentation](https://weber-gesamtausgabe.de/de/Projekt/Editionsrichtlinien_Text.html), I add a paragraph on the revisionDesc section of the documentation to indicate the encoding of the levels of finalization of the transcription with an attribute and three chosen values taken from those proposed on the corresponding article of the [TEI Guidelines](https://www.tei-c.org/release/doc/tei-p5-doc/fr/html/ref-att.docStatus.html) and adapted to our work.