### PR TITLE
Adding the English version

### DIFF
--- a/Guidelines/Documentation-Correspondance.xml
+++ b/Guidelines/Documentation-Correspondance.xml
@@ -1744,6 +1744,7 @@
                     <moduleRef key="msdescription"
                         except="adminInfo colophon custEvent custodialHist depth dim filiation finalRubric heraldry incipit locus locusGrp msFrag msName msPart musicNotation recordHist rubric scriptDesc secFol signatures summary surrogates typeDesc typeNote"
                     />
+                    <moduleRef key="linking" include="ab seg"/>
                 </schemaSpec>
             </div>
         </body>

--- a/Guidelines/out/Documentation-Correspondance.rng
+++ b/Guidelines/out/Documentation-Correspondance.rng
@@ -5,7 +5,7 @@
          xmlns="http://relaxng.org/ns/structure/1.0"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2020-04-06T08:48:45Z. .
+Schema generated from ODD source 2020-05-04T08:46:18Z. .
 TEI Edition: Version 3.6.0. Last updated on
 	16th July 2019, revision daa3cc0b9
 TEI Edition Location: http://www.tei-c.org/Vault/P5/Version 3.6.0/
@@ -467,6 +467,34 @@ Sample values include: 1] all; 2] most; 3] range</a:documentation>
          </attribute>
       </optional>
    </define>
+   <define name="tei_att.datcat.attributes">
+      <ref name="tei_att.datcat.attribute.datcat"/>
+      <ref name="tei_att.datcat.attribute.valueDatcat"/>
+   </define>
+   <define name="tei_att.datcat.attribute.datcat">
+      <optional>
+         <attribute name="datcat" ns="http://www.isocat.org/ns/dcr">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a PID (persistent identifier) that aligns the given element with the appropriate Data Category (or categories) in ISOcat.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="tei_att.datcat.attribute.valueDatcat">
+      <optional>
+         <attribute name="valueDatcat" ns="http://www.isocat.org/ns/dcr">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a PID (persistent identifier) that aligns the content of the given element or the value of the given attribute with the appropriate simple Data Category (or categories) in ISOcat.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
    <define name="tei_att.declarable.attributes">
       <ref name="tei_att.declarable.attribute.default"/>
    </define>
@@ -718,6 +746,7 @@ Suggested values include: 1] internal; 2] external; 3] conjecture</a:documentati
    </define>
    <define name="tei_att.global.attributes">
       <ref name="tei_att.global.rendition.attributes"/>
+      <ref name="tei_att.global.linking.attributes"/>
       <ref name="tei_att.global.facs.attributes"/>
       <ref name="tei_att.global.change.attributes"/>
       <ref name="tei_att.global.responsibility.attributes"/>
@@ -1202,6 +1231,21 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
          </attribute>
       </optional>
    </define>
+   <define name="tei_att.segLike.attributes">
+      <ref name="tei_att.datcat.attributes"/>
+      <ref name="tei_att.fragmentable.attributes"/>
+      <ref name="tei_att.segLike.attribute.function"/>
+   </define>
+   <define name="tei_att.segLike.attribute.function">
+      <optional>
+         <attribute name="function">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the function of the segment.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
    <define name="tei_att.sortable.attributes">
       <ref name="tei_att.sortable.attribute.sortKey"/>
    </define>
@@ -1490,7 +1534,9 @@ Suggested values include: 1] volume; 2] issue; 3] page; 4] line; 5] chapter; 6] 
       </oneOrMore>
    </define>
    <define name="tei_model.segLike">
-      <notAllowed/>
+      <choice>
+         <ref name="tei_seg"/>
+      </choice>
    </define>
    <define name="tei_model.hiLike">
       <choice>
@@ -2376,29 +2422,41 @@ Suggested values include: 1] volume; 2] issue; 3] page; 4] line; 5] chapter; 6] 
    <define name="tei_model.pLike">
       <choice>
          <ref name="tei_p"/>
+         <ref name="tei_ab"/>
       </choice>
    </define>
    <define name="tei_model.pLike_alternation">
       <choice>
          <ref name="tei_p"/>
+         <ref name="tei_ab"/>
       </choice>
    </define>
    <define name="tei_model.pLike_sequence">
       <ref name="tei_p"/>
+      <ref name="tei_ab"/>
    </define>
    <define name="tei_model.pLike_sequenceOptional">
       <optional>
          <ref name="tei_p"/>
+      </optional>
+      <optional>
+         <ref name="tei_ab"/>
       </optional>
    </define>
    <define name="tei_model.pLike_sequenceOptionalRepeatable">
       <zeroOrMore>
          <ref name="tei_p"/>
       </zeroOrMore>
+      <zeroOrMore>
+         <ref name="tei_ab"/>
+      </zeroOrMore>
    </define>
    <define name="tei_model.pLike_sequenceRepeatable">
       <oneOrMore>
          <ref name="tei_p"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="tei_ab"/>
       </oneOrMore>
    </define>
    <define name="tei_model.stageLike">
@@ -2881,6 +2939,7 @@ Suggested values include: 1] volume; 2] issue; 3] page; 4] line; 5] chapter; 6] 
          <ref name="tei_abbr"/>
          <ref name="tei_expan"/>
          <ref name="tei_supplied"/>
+         <ref name="tei_seg"/>
       </choice>
    </define>
    <define name="tei_model.imprintPart">
@@ -7921,6 +7980,14 @@ Sample values include: 1] header; 2] footer; 3] pageNum (page number); 4] lineNu
          <ref name="tei_att.global.rendition.attribute.rend"/>
          <ref name="tei_att.global.rendition.attribute.style"/>
          <ref name="tei_att.global.rendition.attribute.rendition"/>
+         <ref name="tei_att.global.linking.attribute.corresp"/>
+         <ref name="tei_att.global.linking.attribute.synch"/>
+         <ref name="tei_att.global.linking.attribute.sameAs"/>
+         <ref name="tei_att.global.linking.attribute.copyOf"/>
+         <ref name="tei_att.global.linking.attribute.next"/>
+         <ref name="tei_att.global.linking.attribute.prev"/>
+         <ref name="tei_att.global.linking.attribute.exclude"/>
+         <ref name="tei_att.global.linking.attribute.select"/>
          <ref name="tei_att.global.facs.attribute.facs"/>
          <ref name="tei_att.global.change.attribute.change"/>
          <ref name="tei_att.global.responsibility.attribute.cert"/>
@@ -8891,6 +8958,136 @@ Suggested values include: 1] paper; 2] parch (parchment); 3] mixed</a:documentat
             </optional>
          </group>
          <ref name="tei_att.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="tei_att.global.linking.attributes">
+      <ref name="tei_att.global.linking.attribute.corresp"/>
+      <ref name="tei_att.global.linking.attribute.synch"/>
+      <ref name="tei_att.global.linking.attribute.sameAs"/>
+      <ref name="tei_att.global.linking.attribute.copyOf"/>
+      <ref name="tei_att.global.linking.attribute.next"/>
+      <ref name="tei_att.global.linking.attribute.prev"/>
+      <ref name="tei_att.global.linking.attribute.exclude"/>
+      <ref name="tei_att.global.linking.attribute.select"/>
+   </define>
+   <define name="tei_att.global.linking.attribute.corresp">
+      <optional>
+         <attribute name="corresp">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(corresponds) points to elements that correspond to the current element in some way.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="tei_att.global.linking.attribute.synch">
+      <optional>
+         <attribute name="synch">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(synchronous) points to elements that are synchronous with the current element.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="tei_att.global.linking.attribute.sameAs">
+      <optional>
+         <attribute name="sameAs">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to an element that is the same as the current element.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="tei_att.global.linking.attribute.copyOf">
+      <optional>
+         <attribute name="copyOf">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to an element of which the current element is a copy.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="tei_att.global.linking.attribute.next">
+      <optional>
+         <attribute name="next">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the next element of a virtual aggregate of which the current element is part.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="tei_att.global.linking.attribute.prev">
+      <optional>
+         <attribute name="prev">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(previous) points to the previous element of a virtual aggregate of which the current element is part.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="tei_att.global.linking.attribute.exclude">
+      <optional>
+         <attribute name="exclude">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to elements that are in exclusive alternation with the current element.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="tei_att.global.linking.attribute.select">
+      <optional>
+         <attribute name="select">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">selects one or more alternants; if one alternant is selected, the ambiguity or uncertainty is marked as resolved. If more than one alternant is selected, the degree of ambiguity or uncertainty is marked as reduced by the number of alternants not selected.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="tei_ab">
+      <element name="ab">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(anonymous block) contains any arbitrary component-level unit of text, acting as an anonymous container for phrase or inter level elements analogous to, but without the semantic baggage of, a paragraph. [16.3. Blocks, Segments, and Anchors]</a:documentation>
+         <ref name="tei_macro.paraContent"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="myTEI-ab-abstractModel-structure-ab-constraint-report-20">
+            <rule context="tei:ab">
+               <report test="not(ancestor::tei:floatingText) and (ancestor::tei:p or ancestor::tei:ab)          and not(parent::tei:exemplum         |parent::tei:item         |parent::tei:note         |parent::tei:q         |parent::tei:quote         |parent::tei:remarks         |parent::tei:said         |parent::tei:sp         |parent::tei:stage         |parent::tei:cell         |parent::tei:figure)">
+        Abstract model violation: ab may not occur inside paragraphs or other ab elements.
+      </report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="myTEI-ab-abstractModel-structure-l-constraint-report-21">
+            <rule context="tei:ab">
+               <report test="ancestor::tei:l or ancestor::tei:lg">
+        Abstract model violation: Lines may not contain higher-level divisions such as p or ab.
+      </report>
+            </rule>
+         </pattern>
+         <ref name="tei_att.global.attributes"/>
+         <ref name="tei_att.typed.attributes"/>
+         <ref name="tei_att.declaring.attributes"/>
+         <ref name="tei_att.fragmentable.attributes"/>
+         <ref name="tei_att.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="tei_seg">
+      <element name="seg">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(arbitrary segment) represents any segmentation of text below the chunk level. [16.3. Blocks, Segments, and Anchors 6.2. Components of the Verse Line 7.2.5. Speech Contents]</a:documentation>
+         <ref name="tei_macro.paraContent"/>
+         <ref name="tei_att.global.attributes"/>
+         <ref name="tei_att.segLike.attributes"/>
+         <ref name="tei_att.typed.attributes"/>
+         <ref name="tei_att.written.attributes"/>
+         <ref name="tei_att.notated.attributes"/>
          <empty/>
       </element>
    </define>

--- a/Indexes/Index_biblio.xml
+++ b/Indexes/Index_biblio.xml
@@ -3,9 +3,9 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Index des bibliographies</title>
-                <funder>Ministère de lʼEnseignement supérieur, de la Recherche et de lʼInnovation
-                    (MESRI)</funder>
+                <title xml:lang="fr">Index des bibliographies</title>
+                <title xml:lang="en">Index of bibliographies</title>
+                <funder>Ministry of Higher Education, Research and Innovation</funder>
                 <principal>
                     <persName ref="#anne.baillot">
                         <forename>Anne</forename>
@@ -24,7 +24,10 @@
                 <!-- <respStmt>...</respStmt> -->
             </titleStmt>
             <publicationStmt>
-                <publisher>Projet DAHN</publisher>
+                <publisher>
+                    <seg xml:lang="fr">Projet DAHN</seg>
+                    <seg xml:lang="en">DAHN Project</seg>
+                </publisher>
                 <availability>
                     <licence
                         target="https://creativecommons.org/licenses/by/3.0/deed.en"
@@ -33,13 +36,14 @@
                 <date when-iso="...">...</date>
             </publicationStmt>
             <seriesStmt>
-                <title type="main">Correspondance de Paul d'Estournelles de Constant</title>
+                <title type="main">Correspondence of Paul d'Estournelles de Constant</title>
             </seriesStmt>
             <sourceDesc>
                 <p>Born digital</p>
             </sourceDesc>
         </fileDesc>
         <revisionDesc>
+            <change when-iso="2020-05-04" who="#floriane.chiffoleau">Adding the english version</change>
             <change when-iso="2020-03-25" who="#floriane.chiffoleau">Creation of the index</change>
         </revisionDesc>
     </teiHeader>

--- a/Indexes/Index_contributors.xml
+++ b/Indexes/Index_contributors.xml
@@ -3,8 +3,9 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Index des contributeurs</title>
-                <funder>Ministère de lʼEnseignement supérieur, de la Recherche et de lʼInnovation (MESRI)</funder>
+                <title xml:lang="fr">Index des contributeurs</title>
+                <title xml:lang="en">Index of contributors</title>
+                <funder>Ministry of Higher Education, Research and Innovation</funder>
                 <principal>
                     <persName ref="#anne.baillot">
                         <forename>Anne</forename>
@@ -23,20 +24,24 @@
                 <!-- <respStmt>...</respStmt> -->
             </titleStmt>
             <publicationStmt>
-                <publisher>Projet DAHN</publisher>
+                <publisher>
+                    <seg xml:lang="fr">Projet DAHN</seg>
+                    <seg xml:lang="en">DAHN Project</seg>
+                </publisher>
                 <availability>
                     <licence target="https://creativecommons.org/licenses/by/3.0/deed.en">Attribution 3.0 Unported (CC BY 3.0) </licence>
                 </availability>
                 <date when-iso="...">...</date>
             </publicationStmt>
             <seriesStmt>
-                <title type="main">Correspondance de Paul d'Estournelles de Constant</title>
+                <title type="main">Correspondence of Paul d'Estournelles de Constant</title>
             </seriesStmt>
             <sourceDesc>
                 <p>Born digital</p>
             </sourceDesc>
         </fileDesc>
         <revisionDesc>
+            <change when-iso="2020-05-04" who="#floriane.chiffoleau">Adding the english version</change>
             <change when-iso="2020-03-31" who="#floriane.chiffoleau">Creation of the index</change>
         </revisionDesc>
     </teiHeader>

--- a/Indexes/Index_organizations.xml
+++ b/Indexes/Index_organizations.xml
@@ -3,9 +3,9 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Index des organisations</title>
-                <funder>Ministère de lʼEnseignement supérieur, de la Recherche et de lʼInnovation
-                    (MESRI)</funder>
+                <title xml:lang="fr">Index des organisations</title>
+                <title xml:lang="en">Index of organizations</title>
+                <funder>Ministry of Higher Education, Research and Innovation</funder>
                 <principal>
                     <persName ref="#anne.baillot">
                         <forename>Anne</forename>
@@ -24,7 +24,10 @@
                 <!-- <respStmt>...</respStmt> -->
             </titleStmt>
             <publicationStmt>
-                <publisher>Projet DAHN</publisher>
+                <publisher>
+                    <seg xml:lang="fr">Projet DAHN</seg>
+                    <seg xml:lang="en">DAHN Project</seg>
+                </publisher>
                 <availability>
                     <licence
                         target="https://creativecommons.org/licenses/by/3.0/deed.en"
@@ -33,13 +36,14 @@
                 <date when-iso="...">...</date>
             </publicationStmt>
             <seriesStmt>
-                <title type="main">Correspondance de Paul d'Estournelles de Constant</title>
+                <title type="main">Correspondence of Paul d'Estournelles de Constant</title>
             </seriesStmt>
             <sourceDesc>
                 <p>Born digital</p>
             </sourceDesc>
         </fileDesc>
         <revisionDesc>
+            <change when-iso="2020-05-04" who="#floriane.chiffoleau">Adding the english version</change>
             <change when-iso="2020-03-25" who="#floriane.chiffoleau">Creation of the index</change>
         </revisionDesc>
     </teiHeader>

--- a/Indexes/Index_person.xml
+++ b/Indexes/Index_person.xml
@@ -3,8 +3,9 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Index des personnes</title>
-                <funder>Ministère de lʼEnseignement supérieur, de la Recherche et de lʼInnovation (MESRI)</funder>
+                <title xml:lang="fr">Index des personnes</title>
+                <title xml:lang="en">Index of persons</title>
+                <funder>Ministry of Higher Education, Research and Innovation</funder>
                 <principal>
                     <persName ref="#anne.baillot">
                         <forename>Anne</forename>
@@ -23,20 +24,24 @@
                 <!-- <respStmt>...</respStmt> -->
             </titleStmt>
             <publicationStmt>
-                <publisher>Projet DAHN</publisher>
+                <publisher>
+                    <seg xml:lang="fr">Projet DAHN</seg>
+                    <seg xml:lang="en">DAHN Project</seg>
+                </publisher>
                 <availability>
                     <licence target="https://creativecommons.org/licenses/by/3.0/deed.en">Attribution 3.0 Unported (CC BY 3.0) </licence>
                 </availability>
                 <date when-iso="...">...</date>
             </publicationStmt>
             <seriesStmt>
-                <title type="main">Correspondance de Paul d'Estournelles de Constant</title>
+                <title type="main">Correspondence of Paul d'Estournelles de Constant</title>
             </seriesStmt>
             <sourceDesc>
                 <p>Born digital</p>
             </sourceDesc>
         </fileDesc>
         <revisionDesc>
+            <change when-iso="2020-05-04" who="#floriane.chiffoleau">Adding the english version</change>
             <change when-iso="2020-04-02" who="#floriane.chiffoleau">More encoding of the index</change>
             <change when-iso="2020-03-25" who="#floriane.chiffoleau">More encoding of the index</change>
             <change when-iso="2020-03-24" who="#floriane.chiffoleau">Creation of the index</change>

--- a/Indexes/Index_place.xml
+++ b/Indexes/Index_place.xml
@@ -3,9 +3,9 @@
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Index des lieux</title>
-                <funder>Ministère de lʼEnseignement supérieur, de la Recherche et de lʼInnovation
-                    (MESRI)</funder>
+                <title xml:lang="fr">Index des lieux</title>
+                <title xml:lang="en">Index of places</title>
+                <funder>Ministry of Higher Education, Research and Innovation</funder>
                 <principal>
                     <persName ref="#anne.baillot">
                         <forename>Anne</forename>
@@ -24,7 +24,10 @@
                 <!-- <respStmt>...</respStmt> -->
             </titleStmt>
             <publicationStmt>
-                <publisher>Projet DAHN</publisher>
+                <publisher>
+                    <seg xml:lang="fr">Projet DAHN</seg>
+                    <seg xml:lang="en">DAHN Project</seg>
+                </publisher>
                 <availability>
                     <licence
                         target="https://creativecommons.org/licenses/by/3.0/deed.en"
@@ -33,13 +36,14 @@
                 <date when-iso="...">...</date>
             </publicationStmt>
             <seriesStmt>
-                <title type="main">Correspondance de Paul d'Estournelles de Constant</title>
+                <title type="main">Correspondence of Paul d'Estournelles de Constant</title>
             </seriesStmt>
             <sourceDesc>
                 <p>Born digital</p>
             </sourceDesc>
         </fileDesc>
         <revisionDesc>
+            <change when-iso="2020-05-04" who="#floriane.chiffoleau">Adding the english version</change>
             <change when-iso="2020-03-25" who="#floriane.chiffoleau">Creation of the index</change>
         </revisionDesc>
     </teiHeader>

--- a/Transcription/EncodingModel_Letter.xml
+++ b/Transcription/EncodingModel_Letter.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title xml:lang="en">Letter number  from Paul d'Estournelles de Constant to Nicholas Murray Butler ()</title>
                 <title xml:lang="fr">Lettre n° de Paul d'Estournelles de Constant à Nicholas Murray Butler ()</title>
-                <funder>Ministère de lʼEnseignement supérieur, de la Recherche et de lʼInnovation (MESRI)</funder>
+                <funder>Ministry of Higher Education, Research and Innovation</funder>
                 <principal>
                     <persName ref="#anne.baillot">
                         <forename>Anne</forename>
@@ -56,23 +56,32 @@
                 </respStmt>
             </titleStmt>
             <publicationStmt>
-                <publisher>Projet DAHN</publisher>
+                <publisher>
+                    <seg xml:lang="fr">Projet DAHN</seg>
+                    <seg xml:lang="en">DAHN Project</seg>
+                </publisher>
                 <availability>
                     <licence target="https://creativecommons.org/licenses/by/3.0/deed.en">Attribution 3.0 Unported (CC BY 3.0) </licence>
                 </availability>
                 <date when-iso="2020"/>
             </publicationStmt>
             <seriesStmt>
-                <title type="main">Correspondances de Paul d'Estournelles de Constant</title>
-                <title type="genre">Lettres</title>
+                <title type="main">Correspondence of Paul d'Estournelles de Constant</title>
+                <title type="genre">Letters</title>
                 <title type="topic"> </title>
                 <title type="topic"> </title>
             </seriesStmt>
             <sourceDesc>
                 <msDesc>
                     <msIdentifier>
-                        <country key="FR">France</country>
-                        <settlement>Sarthe</settlement>
+                        <country key="FR">
+                            <seg xml:lang="fr">France</seg>
+                            <seg xml:lang="en">France</seg>
+                        </country>
+                        <settlement>
+                            <seg xml:lang="fr">Sarthe</seg>
+                            <seg xml:lang="en">Sarthe</seg>
+                        </settlement>
                         <institution ref="#ADSarthe ">Archives départementales de la Sarthe</institution>
                         <repository>Fonds des archives privées</repository>
                         <collection>Fonds d'Estournelles de Constant</collection>
@@ -92,44 +101,85 @@
                                     <material/>
                                 </support>
                                 <extent>
-                                    <measure type="folio"> feuilles de textes +  feuilles d'annexes</measure>
+                                    <measure type="folio">
+                                        <seg xml:lang="fr"> feuillets de textes +  feuillets d'annexes</seg>
+                                        <seg xml:lang="en"> text folio +  annex folio</seg>
+                                    </measure>
                                     <dimensions unit="cm">
                                         <height/>
                                         <width/>
                                     </dimensions>
                                 </extent>
-                                <foliation>La numérotation des pages a été faite à la machine à écrire, comme le reste de la lettre</foliation>
-                                <condition>La lettre est bien conservée</condition>
+                                <foliation>
+                                    <seg xml:lang="fr">La numérotation des pages a été faite à la machine à écrire, comme le reste de la lettre</seg>
+                                    <seg xml:lang="en">The numerotation has been made with a typewriter, just like the rest of the letter</seg>
+                                </foliation>
+                                <condition>
+                                    <seg xml:lang="fr">La lettre est bien conservée</seg>
+                                    <seg xml:lang="en">The letter is well preserved</seg>
+                                </condition>
                             </supportDesc>
                             <!-- <layoutDesc>
-                                <layout xml:id="lh-senat">Un en-tête, où est écrit "Sénat" en majuscule et souligné, est imprimé en haut à gauche de
-                                    la première feuille de la lettre.</layout>
+                                <layout xml:id="lh-senat">
+                                    <seg xml:lang="fr">Un en-tête, où est écrit "Sénat" en majuscule et souligné, est imprimé en haut à gauche de la
+                                        première feuille de la lettre.</seg>
+                                    <seg xml:lang="en">A letterhead, where an underlined uppercased "Sénat" is written, is printed on the top left of
+                                        the first folio of the letter.</seg>
+                                </layout>
                             </layoutDesc> -->
                         </objectDesc>
                         <handDesc>
-                            <handNote xml:id="major_hand" medium="black_ink" scope="minor" scribe="author" scribeRef="#p0001">Main de l'auteur, Paul
-                                d'Estournelles de Constant, qui écrit sa lettre à l'encre noir à la machine à écrire</handNote>
-                            <handNote xml:id="annotation" medium="pencil" scope="minor" scribe="author" scribeRef="#p0001">Main de l'auteur de la
-                                lettre, Paul d'Estournelles de Constant, qui annote son texte et signe son nom de sa main à la fin</handNote>
-                            <handNote xml:id="stamp" medium="black_ink" scope="minor" scribe="archivist" scribeRef="#ADSarthe">Main de l'archiviste
-                                qui a collecté les lettres et qui a apposé un tampon sur chacune des feuilles du dossier.</handNote>
+                            <handNote xml:id="major_hand" medium="black_ink" scope="minor" scribe="author" scribeRef="#p0001">
+                                <seg xml:lang="fr">Main de l'auteur, Paul d'Estournelles de Constant, qui écrit à l'encre noir à la machine à
+                                    écrire</seg>
+                                <seg xml:lang="en">Hand of the author, Paul d'Estournelles de Constant, who write in black ink with a
+                                    typewriter.</seg>
+                            </handNote>
+                            <handNote xml:id="annotation" medium="pencil" scope="minor" scribe="author" scribeRef="#p0001">
+                                <seg xml:lang="fr">Main de l'auteur Paul d'Estournelles de Constant, qui annote son texte et signe son nom de sa main
+                                    à la fin</seg>
+                                <seg xml:lang="en">Hand of the author, Paul d'Estournelles de Constant, who annotate his text and hand sign it at the
+                                    end.</seg>
+                            </handNote>
+                            <handNote xml:id="stamp" medium="black_ink" scope="minor" scribe="archivist" scribeRef="#ADSarthe">
+                                <seg xml:lang="fr">Main de l'archiviste qui a collecté les lettres et qui a apposé un tampon sur chacune des feuilles
+                                    du dossier.</seg>
+                                <seg xml:lang="en">Hand of the archivist who collected the letters and applied a stamp on each folio.</seg>
+                            </handNote>
                         </handDesc>
                         <additions>
-                            <p>L'institution qui conserve ce fond a apposé sur toutes les feuilles de textes, généralement dans la marge, un tampon où
-                                il est inscrit : <stamp resp="#stamp">Archives de la Sarthe <lb/>Propriété publique</stamp></p>
+                            <seg xml:lang="fr">L'institution qui conserve ce fond a apposé sur toutes les feuilles de textes, généralement dans la
+                                marge, un tampon où il est inscrit : <stamp resp="#stamp">Archives de la Sarthe <lb/>Propriété publique</stamp></seg>
+                            <seg xml:lang="en">The institution that held the collection applied on each folio, usually in the margin, a stamp where it
+                                is written: <stamp resp="#stamp">Archives de la Sarthe <lb/>Propriété publique</stamp></seg>
                         </additions>
-                        <!-- <accMat>La lettre est accompagnée de.</accMat> -->
+                        <!-- <accMat>
+                            <seg xml:lang="fr">La lettre est accompagnée de ... </seg>
+                            <seg xml:lang="en">The letter also contains .. </seg>
+                        </accMat> -->
                     </physDesc>
                     <history>
-                        <origin>La lettre a été écrite à <origPlace> </origPlace> le <origDate when-iso="19..-..-.."> </origDate></origin>
-                        <acquisition>Les papiers de Paul d'Estournelles ont été versés aux Archives départementales de la Sarthe en <date when="1957"
-                            >1957</date> par sa fille <persName>Mme Albert Le Guillard</persName>.</acquisition>
+                        <origin>
+                            <seg xml:lang="fr">La lettre a été écrite à <origPlace>...</origPlace> le <origDate when-iso="19..-..-..">...</origDate></seg>
+                            <seg xml:lang="en">The letter has been written in <origPlace>...</origPlace> on <origDate when-iso="19..-..-..">...</origDate></seg>
+                        </origin>
+                        <acquisition>
+                            <seg xml:lang="fr">Les papiers de Paul d'Estournelles ont été versés aux Archives départementales de la Sarthe en <date
+                                when="1957">1957</date> par sa fille <persName>Mme Albert Le Guillard</persName>.</seg>
+                            <seg xml:lang="en">Paul d'Estournelles papers have been placed at the Departmental Archives of Sarthe in <date when="1957"
+                                >1957</date> by his daughter, <persName>Mrs Albert le Guillard</persName>.</seg>
+                        </acquisition>
                     </history>
                     <additional>
                         <listBibl>
-                            <bibl>De multiples extraits de la correspondance se retrouvent dans <persName>AKHUND Nadine</persName>, <persName>TISON
-                                Stéphane</persName>, <title>En guerre pour la paix, 1914-1919. Correspondance Paul d'Estournelles de Constant et
-                                    Nicholas Murray-Butler</title>.</bibl>
+                            <bibl>
+                                <seg xml:lang="fr">De multiples extraits de la correspondance se retrouvent dans <persName>AKHUND Nadine</persName>, <persName>TISON
+                                    Stéphane</persName>, <title>En guerre pour la paix, 1914-1919. Correspondance Paul d'Estournelles de Constant et
+                                        Nicholas Murray-Butler</title>.</seg>
+                                <seg xml:lang="en">Many correspondence excerpt are found in <persName>AKHUND Nadine</persName>, <persName>TISON
+                                    Stéphane</persName>, <title>En guerre pour la paix, 1914-1919. Correspondance Paul d'Estournelles de Constant et
+                                        Nicholas Murray-Butler</title>.</seg>
+                            </bibl>
                         </listBibl>
                     </additional>
                 </msDesc>
@@ -144,10 +194,12 @@
             </projectDesc>
             <editorialDecl>
                 <correction>
-                    <p>Pas de correction effectuée dans le texte</p>
+                    <p xml:lang="fr">Aucune correction</p>
+                    <p xml:lang="en">No correction</p>
                 </correction>
                 <hyphenation eol="hard" rend="sh">
-                    <p>Toutes les coupures de mots pour fin de ligne (indiquées principalement avec un tiret simple) ont été enlevées.</p>
+                    <p xml:lang="fr">Toutes les coupures de mots pour fin de ligne (indiquées principalement avec un tiret simple) ont été enlevées.</p>
+                    <p xml:lang="en">All the end-of-line hyphenation (made with a single hyphen) have been removed</p>
                 </hyphenation>
             </editorialDecl>
         </encodingDesc>
@@ -172,6 +224,7 @@
             </langUsage>
         </profileDesc>
         <revisionDesc>
+            <change when-iso="2020-05-04" who="#floriane.chiffoleau">Adding the english version</change>
             <change when-iso="2020-04-29" who="#floriane.chiffoleau">Creation of the encoding model</change>
         </revisionDesc>
     </teiHeader>

--- a/Transcription/Lettre477_4février1919.xml
+++ b/Transcription/Lettre477_4février1919.xml
@@ -6,9 +6,7 @@
             <titleStmt>
                 <title xml:lang="en">Letter number 477 from Paul d'Estournelles de Constant to Nicholas Murray Butler (Paris, 4 February 1919)</title>
                 <title xml:lang="fr">Lettre n°477 de Paul d'Estournelles de Constant à Nicholas Murray Butler (Paris, 4 février 1919)</title>
-                <!-- Les lettres étant toutes numérotés, je fais le choix de mettre le numéro dans le titre -->
-                <funder>Ministère de lʼEnseignement supérieur, de la Recherche et de lʼInnovation (MESRI)</funder>
-                <!-- Partenaire du projet DAHN ? -->
+                <funder>Ministry of Higher Education, Research and Innovation</funder>
                 <principal>
                     <persName ref="#anne.baillot">
                         <forename>Anne</forename>
@@ -59,38 +57,42 @@
                 </respStmt>
             </titleStmt>
             <publicationStmt>
-                <publisher>Projet DAHN</publisher>
+                <publisher>
+                    <seg xml:lang="fr">Projet DAHN</seg>
+                    <seg xml:lang="en">DAHN Project</seg>
+                </publisher>
                 <availability>
                     <licence target="https://creativecommons.org/licenses/by/3.0/deed.en">Attribution 3.0 Unported (CC BY 3.0) </licence>
                 </availability>
                 <date when-iso="2020"/>
             </publicationStmt>
             <seriesStmt>
-                <title type="main">Correspondances de Paul d'Estournelles de Constant</title>
-                <title type="genre">Lettres</title>
-                <title type="topic">Relations internationales</title>
-                <title type="topic">Visite diplomatique</title>
+                <title type="main">Correspondence of Paul d'Estournelles de Constant</title>
+                <title type="genre">Letters</title>
+                <title type="topic">International Relations</title>
+                <title type="topic">Diplomatic visit</title>
             </seriesStmt>
             <sourceDesc>
                 <msDesc>
-                    <!-- Faire avec l'EAD de l'inventaire si possible -->
                     <msIdentifier>
-                        <country key="FR">France</country>
-                        <settlement>Sarthe</settlement>
-                        <institution ref="#ADSarthe ">Archives départementales de la Sarthe</institution>
+                        <country key="FR">
+                            <seg xml:lang="fr">France</seg>
+                            <seg xml:lang="en">France</seg>
+                        </country>
+                        <settlement>
+                            <seg xml:lang="fr">Sarthe</seg>
+                            <seg xml:lang="en">Sarthe</seg>
+                        </settlement>
+                        <institution ref="#ADSarthe">Archives départementales de la Sarthe</institution>
                         <repository>Fonds des archives privées</repository>
                         <collection>Fonds d'Estournelles de Constant</collection>
                         <idno>12 J</idno>
-                        <!-- Lieu de conservation de la correspondance (cas exceptionnelle des lettres 11 à 100, 
-                            qui demandera une modification pour mettre Carnegie) -->
                     </msIdentifier>
                     <msContents>
                         <msItem>
-                            <!-- Détails à mettre que si cela ne correspond à chaque fois qu'à une seule lettre -->
                             <docDate when="1919-02-04"/>
-                            <note resp="#floriane.chiffoleau">Cette lettre s'accompagne d'une annexe</note>
-                            <note type="keyword" resp="#floriane.chiffoleau">Président Wilson</note>
-                            <!-- Mettre des mots-clés correspondants au sujet de la lettre -->
+                            <note resp="#floriane.chiffoleau">This letter also contains an annex</note>
+                            <note type="keyword" resp="#floriane.chiffoleau">President Wilson</note>
                         </msItem>
                     </msContents>
                     <physDesc>
@@ -101,49 +103,91 @@
                                     <!-- A remplir par la suite : papier ? -->
                                 </support>
                                 <extent>
-                                    <measure type="folio">5 feuilles de textes + 3 feuilles d'annexes</measure>
+                                    <measure type="folio">
+                                        <seg xml:lang="fr">5 feuillets de textes + 3 feuillets d'annexes</seg>
+                                        <seg xml:lang="en">5 text folio + 3 annex folio</seg>
+                                    </measure>
                                     <dimensions unit="cm">
                                         <height/>
                                         <width/>
                                         <!-- Dimensions d'une page de l'époque : A4 ? -->
                                     </dimensions>
                                 </extent>
-                                <foliation>La numérotation des pages a été faite à la machine à écrire, comme le reste de la lettre</foliation>
-                                <condition>La lettre est bien conservée</condition>
+                                <foliation>
+                                    <seg xml:lang="fr">La numérotation des pages a été faite à la machine à écrire, comme le reste de la lettre</seg>
+                                    <seg xml:lang="en">The numerotation has been made with a typewriter, just like the rest of the letter</seg>
+                                </foliation>
+                                <condition>
+                                    <seg xml:lang="fr">La lettre est bien conservée</seg>
+                                    <seg xml:lang="en">The letter is well preserved</seg>
+                                </condition>
                             </supportDesc>
-                            <!-- Optionnel car ne figure par sur toutes les lettres de la correspondance
+                            <!-- Optionnel car ne figure par sur toutes les lettres de la correspondance 
                             <layoutDesc>
-                                <layout xml:id="lh-senat">Un en-tête, où est écrit "Sénat" en majuscule et souligné, est imprimé en haut à gauche de
-                                    la première feuille de la lettre.</layout>
+                                <layout xml:id="lh-senat">
+                                    <seg xml:lang="fr">Un en-tête, où est écrit "Sénat" en majuscule et souligné, est imprimé en haut à gauche de la
+                                        première feuille de la lettre.</seg>
+                                    <seg xml:lang="en">A letterhead, where an underlined uppercased "Sénat" is written, is printed on the top left of
+                                        the first folio of the letter.</seg> 
+                                </layout>
                             </layoutDesc> -->
                         </objectDesc>
                         <handDesc>
-                            <handNote xml:id="major_hand" medium="black_ink" scope="minor" scribe="author" scribeRef="#p0001">Main de l'auteur, Paul
-                                d'Estournelles de Constant, qui écrit sa lettre à l'encre noir à la machine à écrire</handNote>
-                            <handNote xml:id="annotation" medium="pencil" scope="minor" scribe="author" scribeRef="#p0001">Main de l'auteur de la
-                                lettre, Paul d'Estournelles de Constant, qui annote son texte et signe son nom de sa main à la fin</handNote>
-                            <handNote xml:id="stamp" medium="black_ink" scope="minor" scribe="archivist" scribeRef="#ADSarthe">Main de l'archiviste
-                                qui a collecté les lettres et qui a apposé un tampon sur chacune des feuilles du dossier.</handNote>
+                            <handNote xml:id="major_hand" medium="black_ink" scope="minor" scribe="author" scribeRef="#p0001">
+                                <seg xml:lang="fr">Main de l'auteur, Paul d'Estournelles de Constant, qui écrit à l'encre noir à la machine à
+                                    écrire</seg>
+                                <seg xml:lang="en">Hand of the author, Paul d'Estournelles de Constant, who write in black ink with a
+                                    typewriter.</seg>
+                            </handNote>
+                            <handNote xml:id="annotation" medium="pencil" scope="minor" scribe="author" scribeRef="#p0001">
+                                <seg xml:lang="fr">Main de l'auteur Paul d'Estournelles de Constant, qui annote son texte et signe son nom de sa main
+                                    à la fin</seg>
+                                <seg xml:lang="en">Hand of the author, Paul d'Estournelles de Constant, who annotate his text and hand sign it at the
+                                    end.</seg>
+                            </handNote>
+                            <handNote xml:id="stamp" medium="black_ink" scope="minor" scribe="archivist" scribeRef="#ADSarthe">
+                                <seg xml:lang="fr">Main de l'archiviste qui a collecté les lettres et qui a apposé un tampon sur chacune des feuilles
+                                    du dossier.</seg>
+                                <seg xml:lang="en">Hand of the archivist who collected the letters and applied a stamp on each folio.</seg>
+                            </handNote>
                         </handDesc>
                         <additions>
-                            <p>L'institution qui conserve ce fond a apposé sur toutes les feuilles de textes, généralement dans la marge, un tampon où
-                                il est inscrit : <stamp resp="#stamp">Archives de la Sarthe <lb/>Propriété publique</stamp></p>
+                            <seg xml:lang="fr">L'institution qui conserve ce fond a apposé sur toutes les feuilles de textes, généralement dans la
+                                marge, un tampon où il est inscrit : <stamp resp="#stamp">Archives de la Sarthe <lb/>Propriété publique</stamp></seg>
+                            <seg xml:lang="en">The institution that held the collection applied on each folio, usually in the margin, a stamp where it
+                                is written: <stamp resp="#stamp">Archives de la Sarthe <lb/>Propriété publique</stamp></seg>
                         </additions>
-                        <!-- <sealDesc/> non présent car il n'y a aucune présence de sceau dans notre correspondance -->
-                        <accMat>La lettre est accompagnée d'une annexe de trois pages qui se composent d'un découpage de plusieurs articles de
-                            journaux coupés et collés sur les pages.</accMat>
+                        <accMat>
+                            <seg xml:lang="fr">La lettre est accompagnée d'une annexe de trois pages qui se composent d'un découpage de plusieurs
+                                articles de journaux coupés et collés sur les pages.</seg>
+                            <seg xml:lang="en">The letter also contains a three pages annexe which consists of cutouts of many newspapers articles
+                                cuted and pasted on the pages.</seg>
+                        </accMat>
                     </physDesc>
                     <history>
-                        <origin>La lettre a été écrite à <origPlace>Paris</origPlace> le <origDate when-iso="1919-02-04">4 février
-                            1919</origDate></origin>
-                        <acquisition>Les papiers de Paul d'Estournelles ont été versés aux Archives départementales de la Sarthe en <date when="1957"
-                                >1957</date> par sa fille <persName>Mme Albert Le Guillard</persName>.</acquisition>
+                        <origin>
+                            <seg xml:lang="fr">La lettre a été écrite à <origPlace>Paris</origPlace> le <origDate when-iso="1919-02-04">4 février
+                                    1919</origDate></seg>
+                            <seg xml:lang="en">The letter has been written in <origPlace>Paris</origPlace> on <origDate when-iso="1919-02-04">February
+                                    4, 1919</origDate></seg>
+                        </origin>
+                        <acquisition>
+                            <seg xml:lang="fr">Les papiers de Paul d'Estournelles ont été versés aux Archives départementales de la Sarthe en <date
+                                    when="1957">1957</date> par sa fille <persName>Mme Albert Le Guillard</persName>.</seg>
+                            <seg xml:lang="en">Paul d'Estournelles papers have been placed at the Departmental Archives of Sarthe in <date when="1957"
+                                    >1957</date> by his daughter, <persName>Mrs Albert le Guillard</persName>.</seg>
+                        </acquisition>
                     </history>
                     <additional>
                         <listBibl>
-                            <bibl>De multiples extraits de la correspondance se retrouvent dans <persName>AKHUND Nadine</persName>, <persName>TISON
+                            <bibl>
+                                <seg xml:lang="fr">De multiples extraits de la correspondance se retrouvent dans <persName>AKHUND Nadine</persName>, <persName>TISON
                                     Stéphane</persName>, <title>En guerre pour la paix, 1914-1919. Correspondance Paul d'Estournelles de Constant et
-                                    Nicholas Murray-Butler</title>.</bibl>
+                                    Nicholas Murray-Butler</title>.</seg>
+                                <seg xml:lang="en">Many correspondence excerpt are found in <persName>AKHUND Nadine</persName>, <persName>TISON
+                                    Stéphane</persName>, <title>En guerre pour la paix, 1914-1919. Correspondance Paul d'Estournelles de Constant et
+                                        Nicholas Murray-Butler</title>.</seg>
+                            </bibl>
                         </listBibl>
                     </additional>
                 </msDesc>
@@ -158,10 +202,12 @@
             </projectDesc>
             <editorialDecl>
                 <correction>
-                    <p>Pas de correction effectuée dans le texte</p>
+                    <p xml:lang="fr">Aucune correction</p>
+                    <p xml:lang="en">No correction</p>
                 </correction>
                 <hyphenation eol="hard" rend="sh">
-                    <p>Toutes les coupures de mots pour fin de ligne (indiquées principalement avec un tiret simple) ont été enlevées.</p>
+                    <p xml:lang="fr">Toutes les coupures de mots pour fin de ligne (indiquées principalement avec un tiret simple) ont été enlevées.</p>
+                    <p xml:lang="en">All the end-of-line hyphenation (made with a single hyphen) have been removed</p>
                 </hyphenation>
             </editorialDecl>
         </encodingDesc>
@@ -186,6 +232,7 @@
             </langUsage>
         </profileDesc>
         <revisionDesc status="proposed">
+            <change when-iso="2020-05-04" who="#floriane.chiffoleau">Adding the english version</change>
             <change when-iso="2020-04-23" who="#floriane.chiffoleau">Transcription completed</change>
             <change when-iso="2020-04-02" who="#floriane.chiffoleau">Modifications on the encoding</change>
             <change when-iso="2020-04-01" who="#floriane.chiffoleau">Modifications on the encoding</change>
@@ -272,9 +319,9 @@
                     conçoit, cela est nécessaire, dans la mesure où<lb/> nous ne rendrons pourtant pas impossible la reprise d’une<lb/> vie normale
                     aux Allemands. Mais efforçons-nous de conser<lb break="no"/>ver d’autant plus la confiance et l’amitié de tous nos<lb/> Alliés. Ne
                     les traitons ni par la défiance, ni par l’in<lb break="no"/>gratitude, ni, par le mépris.</p>
-                <p rend="indent">Je vous écris cela, à titre personne<add place="inline" hand="#annotation">l</add>, sachant<lb/> bien que vous n’oubliez pas le souci que j’ai toujours pris<lb/>
-                    de ne rien publier mais qui puisse affaiblir mon Gouverne<lb break="no"/>ment, non seulement devant l’ennemi mais devant ses
-                    Alliés.</p>
+                <p rend="indent">Je vous écris cela, à titre personne<add place="inline" hand="#annotation">l</add>, sachant<lb/> bien que vous
+                    n’oubliez pas le souci que j’ai toujours pris<lb/> de ne rien publier mais qui puisse affaiblir mon Gouverne<lb break="no"/>ment,
+                    non seulement devant l’ennemi mais devant ses Alliés.</p>
                 <p rend="indent">Cependant je ne dois pas, je ne puis pas<lb/> toujours me taire. Je n’attaque pas Clemenceau. Vous<lb/> m’avez vu
                     maintes fois reconnaître sa supériorité, comparée<lb/> à la médiocrité de tant d’autres. Je n’oublie pas qu’il<lb/> a été l’ami
                     des petits peuples en bien des cas, l’ami des<lb/> Grecs, par exemple, envers et contre tous, et jusqu’à <pb n="5"


### PR DESCRIPTION
In response to the issue #3 I modified most of the documents from the repository to add an English version of the metadata, which could be useful later.
I had to add a new module on the ODD (linking) to encode the rest of the documents with the right tag.